### PR TITLE
create responsiveness for navbar from 730 to 1000px

### DIFF
--- a/src/Components/Navbar/Navbar.css
+++ b/src/Components/Navbar/Navbar.css
@@ -38,13 +38,49 @@ nav ul li a.active{
 /* Media query for tablets */
 @media(max-width: 1000px){
     .logo{
-        width: 140px;
+        width: 100px;
     }
     nav ul li{
-        margin: 10px 15px;
+        margin: 8px 12px;
     }
 }
 
+@media (max-width: 730px){
+  nav {
+    padding: 15px 20px; /* Adjust padding for better spacing */
+  }
+
+  .logo {
+    width: 80px;
+  }
+
+  nav ul {
+    position: absolute; /* Change position to absolute */
+    top: 60px; /* Adjust top position */
+    right: 20px; /* Adjust right position */
+    background: #212ea0;
+    z-index: 10; /* Increase z-index to show above other content */
+    width: 200px;
+    padding-top: 20px; /* Adjust padding-top */
+    transition: 0.5s;
+  }
+
+  nav ul li {
+    display: block;
+    margin: 10px 0; /* Adjust margin */
+    text-align: center; /* Center align menu items */
+  }
+
+  .menu-icon {
+    display: block;
+    width: 30px;
+    cursor: pointer;
+  }
+
+  .hide-mobile-menu {
+      display: none;
+  }
+}
 
 /* SmartPhone Media query */
 @media (max-width: 600px) {


### PR DESCRIPTION
### **What does this change do:**

1. Makes the navbar responsive from 730px to 1000px

### **Approach**
1. Change the logo width upto 1000px
2. Change the margin so the text in media query max-width:1000px so the text doesn't entend to next line from 730px-1000px
3. Added a custom media query till 730px to only use the mobile navbar upto. Had to create custom query because the logo sizes are different for 600px and the 730px max-width media queries

### **Before:**
![Screenshot from 2024-05-17 13-56-52](https://github.com/Priyaaa1/StartConnect-Hub/assets/109733360/3475fcbf-1a57-4089-a012-b02bae529179)

![Screenshot from 2024-05-17 13-57-41](https://github.com/Priyaaa1/StartConnect-Hub/assets/109733360/c937d0a5-56b1-46a8-8744-dc527ea6dc73)


### **After:**
![Screenshot from 2024-05-17 13-57-12](https://github.com/Priyaaa1/StartConnect-Hub/assets/109733360/854e37cd-d737-4073-b1ca-144477a8e961)


![Screenshot from 2024-05-17 13-57-48](https://github.com/Priyaaa1/StartConnect-Hub/assets/109733360/36f2222f-b7e0-4e0d-8ada-be4d470f23c7)

