### PR TITLE
Fixed #138 (taking only number input in phone number while sending message)

### DIFF
--- a/src/Components/Contact/Contact.jsx
+++ b/src/Components/Contact/Contact.jsx
@@ -67,6 +67,9 @@ const Contact = () => {
           <input
             type="tel"
             name="phone"
+            pattern="[0-9]*"
+            minLength="10"
+            maxLength="10"
             placeholder="Enter your phone"
             required
           ></input>


### PR DESCRIPTION
Earlier the phone number input was accepting anything as input like alphabets,operators etc. Now i have added some more restriction by which only Number input of length 10 will be accepted.
![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/123561974/329f77b4-e20e-40a0-8056-694f8beff905)
![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/123561974/252479b9-1fcc-4e99-8f30-05a5a8146255)



There was some issue , i was unable to run the website on my system. Therefore i couldn't test other methods for this.
Please consider this and merge my PR.