### PR TITLE
Solved the issue of page rendering at bottom

### DIFF
--- a/src/Pages/FullServiceFund.jsx
+++ b/src/Pages/FullServiceFund.jsx
@@ -1,7 +1,10 @@
-import React from 'react'
+import {React,useEffect} from 'react'
 import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
 const FullServiceFund = () => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+      }, []);
   return (
     <FullServicefundPageWrapper>
     <h1 >Full Service Fund</h1>


### PR DESCRIPTION
Solved issue #274  Now the page /fullservicefund opens at the top when the respective route is hit.

https://github.com/Priyaaa1/StartConnect-Hub/assets/154724111/b3d9c899-dfbf-42e9-80a0-f899e4934654

