### PR TITLE
Updated "Contact Email" in Different Pages 

### DIFF
--- a/src/Components/Contact/Contact.jsx
+++ b/src/Components/Contact/Contact.jsx
@@ -46,7 +46,7 @@ const Contact = () => {
         </p>
         <ul>
           <li>
-            <img src={mail_icon} alt=""></img>Contact@StartConnectHub.in
+            <img src={mail_icon} alt=""></img><a href="mailto:startconnecthub@gmail.com"> startconnecthub@gmail.com</a>
           </li>
           <li>
             <img src={phone_icon} alt=""></img>+91 1234567890

--- a/src/Components/FAQ/data.js
+++ b/src/Components/FAQ/data.js
@@ -21,7 +21,7 @@ const data = [
       id  : '4',
       question: "How can I contact customer support?",
       answer:
-        "You can reach our customer support team by emailing support@startConnectHub.com. We’re here to help!",
+        "You can reach our customer support team by emailing startconnecthub@gmail.com. We’re here to help!",
     }
   ];
 

--- a/src/Pages/PrivacyPolicy.jsx
+++ b/src/Pages/PrivacyPolicy.jsx
@@ -10,7 +10,7 @@ const PrivacyPolicy = () => {
         <h1>Privacy Policy</h1>
         <section>
           <p>Last updated: May 19, 2024</p>
-          <p>Welcome to StartConnect Hub! We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy or our practices regarding your personal information, please contact us at startconnect@hub.com.</p>
+          <p>Welcome to StartConnect Hub! We are committed to protecting your personal information and your right to privacy. If you have any questions or concerns about our policy or our practices regarding your personal information, please contact us at <a href="mailto:startconnecthub@gmail.com"> startconnecthub@gmail.com</a>.</p>
         </section>
         <section>
           <h2>Information We Collect</h2>
@@ -42,7 +42,7 @@ const PrivacyPolicy = () => {
         </section>
         <section>
           <h2>Your Data Protection Rights</h2>
-          <p>You have certain rights under data protection laws regarding your personal information. These may include the right to access, correct, update, or delete your personal information. If you wish to exercise any of these rights, please contact us at startconnect@hub.com.</p>
+          <p>You have certain rights under data protection laws regarding your personal information. These may include the right to access, correct, update, or delete your personal information. If you wish to exercise any of these rights, please contact us at <a href="mailto:startconnecthub@gmail.com"> startconnecthub@gmail.com</a>.</p>
         </section>
         <section>
           <h2>Changes to This Privacy Policy</h2>

--- a/src/Pages/PrivacyPolicy.jsx
+++ b/src/Pages/PrivacyPolicy.jsx
@@ -50,7 +50,7 @@ const PrivacyPolicy = () => {
         </section>
         <section>
           <h2>Contact Us</h2>
-          <p>If you have any questions or comments about this policy, you may email us at startconnect@hub.com.</p>
+          <p>If you have any questions or comments about this policy, you may email us at <a href="mailto:startconnecthub@gmail.com"> startconnecthub@gmail.com</a></p>
         </section>
       </div>
     </PolicyWrapper>

--- a/src/Pages/TermsAndConditions.jsx
+++ b/src/Pages/TermsAndConditions.jsx
@@ -40,7 +40,7 @@ const TermsAndConditions = () => {
         </section>
         <section>
           <h2>7. Contact Us</h2>
-          <p>If you have any questions or comments about these Terms and Conditions, you may email us at startconnect@hub.com.</p>
+          <p>If you have any questions or comments about these Terms and Conditions, you may email us at <a href="mailto:startconnecthub@gmail.com"> startconnecthub@gmail.com</a>.</p>
         </section>
       </div>
     </TermsWrapper>


### PR DESCRIPTION
Hey @Priyaaa1  | Issue Closes #497 

I have updated the "Contact Email" with `startconnecthub@gmail.com` on the following Pages:

### **Contact Us** 

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/101971980/222eaa82-8b4b-4283-8947-f1197a0616fd)

### **FAQ**

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/101971980/2b0e928b-f1de-4406-882a-f9cedaafb30e)

### **Legal Pages: Privacy Policy, Terms and Conditions**

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/101971980/4cb7d8da-e8f3-4fa9-8475-575c7476e776)

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/101971980/6eb86076-e6d0-400a-b87e-0aa9b860f386)

Additionally, I have made sure after the users click on the mail id it will redirect them to the Mail Window.