### PR TITLE
Designed "Licensing" Page Reflecting "MIT License" 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 StartConnect-Hub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import 'react-chatbot-kit/build/main.css';
 import Explore from './Pages/Explore';
 import PrivacyPolicy from "./Pages/PrivacyPolicy";
 import TermsAndConditions from "./Pages/TermsAndConditions";
+import Licensing from './Pages/Licensing';
 import VisionAndMission from "./Pages/VisionAndMission";
 import HowItWorks from "./Pages/HowItWorks";
 import InvestorManagementPage from "./Pages/InvestorManagementPage";
@@ -69,6 +70,7 @@ const App = () => {
               <Route path='/explore' element={<Explore />} />
               <Route path='/privacypolicy' element={<PrivacyPolicy />} />
               <Route path='/termsandconditions' element={<TermsAndConditions />} />
+              <Route path='/licensing' element={<Licensing />} />
               <Route path='/visionandmission' element={<VisionAndMission />} />
               <Route path='/howitworks' element={<HowItWorks />} />
               <Route path='/investormanagementpage' element={<InvestorManagementPage />} />

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -69,6 +69,7 @@ const Footer = () => {
             <ul className='footer-links'>
             <NavLink to="/privacypolicy"><li className='footer-link'>Privacy Policy</li></NavLink>
               <NavLink to="/termsandconditions"><li className='footer-link'>Terms & Conditions</li></NavLink>
+              <NavLink to="/licensing"><li className='footer-link'>Licensing</li></NavLink>
               <NavLink to="/visionandmission"><li className='footer-link'>Vision and Mission</li></NavLink>
               <li className='footer-link'>Career</li>
             </ul>

--- a/src/Pages/Licensing.jsx
+++ b/src/Pages/Licensing.jsx
@@ -1,0 +1,72 @@
+import {React,useEffect} from 'react';
+import styled from 'styled-components';
+
+
+const Container = styled.div`
+  max-width: 800px;
+  margin: 0 auto;
+  margin-top: 60px;
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  background-color: #f9f9f9;
+  border-radius: 5px;
+`;
+
+const Title = styled.h1`
+  font-size: 2em;
+  margin-bottom: 20px;
+  text-align: left;
+`;
+
+const Paragraph = styled.p`
+  font-size: 1em;
+  line-height: 1.6;
+  margin-bottom: 8px;
+`;
+
+const Subtitle = styled.h2`
+  font-size: 1.5em;
+  margin-bottom: 8px;
+  justify-content: left;
+  padding: 0;
+`;
+
+const Licensing = () => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+      }, []);
+  return (
+    <Container>
+      <Title>Licensing</Title>
+      <Paragraph>Welcome to StartConnect Hub! This website is licensed under the MIT License. This page outlines the terms of the license and provides details on how you can use, modify, and distribute our software.</Paragraph>
+      <Subtitle>MIT License</Subtitle>
+      <Paragraph>Copyright (c) 2024 StartConnect-Hub</Paragraph>
+      <Paragraph>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+      </Paragraph>
+      <Paragraph>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+      </Paragraph>
+      <Paragraph>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+      </Paragraph>
+      <Subtitle>Contact Information</Subtitle>
+      <p>If you have any questions or concerns about this licensing agreement, please contact us at Email: <a href="mailto:startconnecthub@gmail.com">startconnecthub@gmail.com</a> </p>
+
+    </Container>
+  );
+};
+
+export default Licensing;


### PR DESCRIPTION
Hey @Priyaaa1 issue closes #506 


I have added "MIT License" to the website and the repository.

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/163530398/a1fae9b4-9443-483b-8b15-470e745ae4ae)

also i have designed dedicated page for licensing page reflecting MIT license.

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/163530398/1b686e50-1af2-4845-aa3d-fe860a7c9032)

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/163530398/3dfa7ce3-63ec-4052-a5de-f56312374f35)


also i have made sure that the page is responsive

![image](https://github.com/Priyaaa1/StartConnect-Hub/assets/163530398/96a98d0e-e614-4aa1-baee-3b186161c74d)


Please take a look at and review it. Thank You


