### PR TITLE
Repositioned google translate from top to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,18 +21,6 @@
         font-family: Arial, sans-serif;
       }
 
-      #translate-container {
-        position: fixed;
-        top: 80px; /* Adjust this value to move the box down from the top */
-        left: 20px; /* Keeps the box aligned to the left */
-        background: #fff;
-        padding: 10px;
-        border: 1px solid #ddd;
-        border-radius: 5px;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-        z-index: 1000;
-      }
-
       /* Optional: Add a dark mode for your website */
       .dark-mode {
         background-color: #343434;
@@ -42,15 +30,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <div id="translate-container">
-      <div id="google_translate_element"></div>
-    </div>
     <script type="module" src="/src/main.jsx"></script>
-    <script type="text/javascript">
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
-      }
-    </script>
-    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <script id="google-translate-script" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" async></script>
   </body>
 </html>

--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -7,22 +7,28 @@ import { scroller } from "react-scroll";
 import Visitors from "../Visitors";
 import { AiFillHome, AiFillInfoCircle, AiFillPhone, AiFillQuestionCircle, AiFillLock, AiFillFileText } from "react-icons/ai";
 import { BiBook, BiSupport, BiCommentDetail, BiBriefcase, BiGroup } from "react-icons/bi";
+import GoogleTranslateComponent from "../GoogleTranslate/GoogleTranslate";
 
 const Footer = () => {
   const [sticky, setSticky] = useState(false);
   const [mobileMenu, setMobileMenu] = useState(false);
   const navigate = useNavigate();
 
+  
+
   useEffect(() => {
+    
+
     const handleScroll = () => {
       setSticky(window.scrollY > 200);
     };
-
+    
     window.addEventListener("scroll", handleScroll);
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
   }, []);
+
 
   const toggleMenu = () => {
     setMobileMenu(!mobileMenu);
@@ -99,6 +105,16 @@ const Footer = () => {
               </a>
               <li className="footer-link"><AiFillPhone className="footer-icon" /> Media</li>
             </ul>
+
+
+
+            {/* <div id="translate-container">
+              <div id="google_translate_element"></div>
+            </div> */}
+            <GoogleTranslateComponent />
+
+
+
           </div>
           <div className="footer-2">
             <p className="footer-section-title">Need Help</p>

--- a/src/Components/GoogleTranslate/GoogleTranslate.jsx
+++ b/src/Components/GoogleTranslate/GoogleTranslate.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useRef } from "react";
+
+const TranslateComponent = () => {
+  const googleTranslateRef = useRef(null);
+
+  useEffect(() => {
+    let intervalId = null;
+    const checkGoogleTranslate = () => {
+      if (window.google && window.google.translate && window.google.translate.TranslateElement.InlineLayout) {
+        clearInterval(intervalId);
+        new window.google.translate.TranslateElement(
+          {
+            pageLanguage: "en",
+            includedLanguages: "af,ach,ak,am,ar,az,be,bem,bg,bh,bn,br,bs,ca,chr,ckb,co,crs,cs,cy,da,de,ee,el,en,eo,es,es-419,et,eu,fa,fi,fo,fr,fy,ga,gaa,gd,gl,gn,gu,ha,haw,hi,hr,ht,hu,hy,ia,id,ig,is,it,iw,ja,jw,ka,kg,kk,km,kn,ko,kri,ku,ky,la,lg,ln,lo,loz,lt,lua,lv,mfe,mg,mi,mk,ml,mn,mo,mr,ms,mt,ne,nl,nn,no,nso,ny,nyn,oc,om,or,pa,pcm,pl,ps,pt-BR,pt-PT,qu,rm,rn,ro,ru,rw,sd,sh,si,sk,sl,sn,so,sq,sr,sr-ME,st,su,sv,sw,ta,te,tg,th,ti,tk,tl,tn,to,tr,tt,tum,tw,ug,uk,ur,uz,vi,wo,xh,yi,yo,zh-CN,zh-TW,zu",
+            layout: window.google.translate.TranslateElement.InlineLayout.VERTICAL
+          },
+          googleTranslateRef.current
+        );
+      }
+    };
+    intervalId = setInterval(checkGoogleTranslate, 100);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <div>
+      <div ref={googleTranslateRef}></div>
+    </div>
+  );
+};
+
+export default TranslateComponent;

--- a/src/Components/GoogleTranslate/googleTranslate.css
+++ b/src/Components/GoogleTranslate/googleTranslate.css
@@ -1,0 +1,11 @@
+#translate-container {
+    /* position: fixed; */
+    height: 100px;
+    width: 300px;
+    background: #fff;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+  }


### PR DESCRIPTION
## Description

I have moved Google Translate component, Which was present at top, to the footer section of website. This improves the UI of site, removing unecessary distraction from langind page.

## Related Issues

- Closes #695 

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]
![Screenshot 2024-08-06 165656](https://github.com/user-attachments/assets/7660cc4c-7b26-4e57-ba2c-7ba534f7ca86)
![Screenshot 2024-08-06 165641](https://github.com/user-attachments/assets/7730fdaf-7fc0-4efe-82aa-93e3b2caeb5d)
![Screenshot 2024-08-06 165627](https://github.com/user-attachments/assets/f5d0756a-141e-44c5-978b-661cb2683510)


## Checklist

- [X] I have gone through the [contributing guide](https://github.com/Anishkagupta04/RAPIDOC-HEALTHCARE-WEBSITE-/)
- [X] I have updated my branch and synced it with project `main` branch before making this PR
- [X] I have performed a self-review of my code
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]

working fine in netlify deployment preview
![Screenshot 2024-08-06 170546](https://github.com/user-attachments/assets/d8174557-0398-4068-ab56-080402f5bbfe)

